### PR TITLE
Ensure consecutive HTML comments don't crash

### DIFF
--- a/Example/Sources/DemoViewController.swift
+++ b/Example/Sources/DemoViewController.swift
@@ -16,6 +16,9 @@ This is ~~strikethrough~~.
 
 Inline `code` too. You can do ```a silly amount of back ticks``` too.
 
+<!-- Here's an HTML comment -->
+<!-- and a second one with some more content -->
+
 ---
 
 > Blockquote

--- a/Sources/MarkdownKit/Models/Nodes/Node.swift
+++ b/Sources/MarkdownKit/Models/Nodes/Node.swift
@@ -55,6 +55,12 @@ public class Node {
             return nil
         }
 
+        // cmark can return a -1 range that references the previous line, causing
+        // exceptions to be thrown within various NSString/NSAttributedString APIs.
+        if let end = end, start.line > end.line {
+            return nil
+        }
+
         guard let content = document?.content.map(NSString.init) else {
             assertionFailure("Missing `document.content`")
             return nil

--- a/Tests/MarkdownKitTests/LocationTests.swift
+++ b/Tests/MarkdownKitTests/LocationTests.swift
@@ -10,4 +10,19 @@ final class LocationsTests: XCTestCase {
         let paragraph = document.children.first!
         XCTAssertEqual(markdown, paragraph.content)
     }
+
+    func testRangesWithConsecutiveHTMLComments() {
+        let markdown = """
+<!-- Here's an HTML comment -->
+<!-- and a second one with some more content -->
+"""
+        let document = Parser.parse(markdown)!
+        XCTAssertEqual(markdown, document.content)
+
+        let firstLine = document.children.first
+        let secondLine = document.children[document.children.startIndex.advanced(by: 1)]
+
+        XCTAssertNotNil(firstLine?.range)
+        XCTAssertNil(secondLine.range)
+    }
 }

--- a/Tests/MarkdownKitTests/LocationTests.swift
+++ b/Tests/MarkdownKitTests/LocationTests.swift
@@ -10,19 +10,4 @@ final class LocationsTests: XCTestCase {
         let paragraph = document.children.first!
         XCTAssertEqual(markdown, paragraph.content)
     }
-
-    func testRangesWithConsecutiveHTMLComments() {
-        let markdown = """
-<!-- Here's an HTML comment -->
-<!-- and a second one with some more content -->
-"""
-        let document = Parser.parse(markdown)!
-        XCTAssertEqual(markdown, document.content)
-
-        let firstLine = document.children.first
-        let secondLine = document.children[document.children.startIndex.advanced(by: 1)]
-
-        XCTAssertNotNil(firstLine?.range)
-        XCTAssertNil(secondLine.range)
-    }
 }

--- a/Tests/MarkdownKitTests/TextStorageTests.swift
+++ b/Tests/MarkdownKitTests/TextStorageTests.swift
@@ -1,0 +1,14 @@
+import MarkdownKit
+import XCTest
+
+final class TextStorageTests: XCTestCase {
+    func testRange() {
+        let markdown = """
+<!-- Here's an HTML comment -->
+<!-- and a second one with some more content -->
+"""
+        let storage = TextStorage()
+        storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: markdown)
+        XCTAssertNoThrow(storage.parseIfNeeded())
+    }
+}


### PR DESCRIPTION
Related to https://github.com/github/mobile-ios/issues/3435

With two consecutive HTML comments, cmark will report a negative range for the all HTML comments after the first. Using this negative range with NSAttributedString APIs would cause an exception to be thrown that would crash the app if unhandled.

This ensures that only valid, positive ranges are passed from cmark to NSAttributedString APIs. However, any HTML comments after the first are not given any attributes, and will thus render as base text.