### PR TITLE
Fix build with Swift 5.4 and Xcode 12.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -10,7 +10,12 @@ let package = Package(
     ],
     targets: [
         .target(name: "libcmark"),
-        .target(name: "MarkdownKitObjC"),
+        .target(
+            name: "MarkdownKitObjC",
+            cSettings: [
+                .headerSearchPath("include"),
+            ]
+        ),
         .target(name: "MarkdownKit", dependencies: ["libcmark", "MarkdownKitObjC"]),
         .testTarget(name: "MarkdownKitTests", dependencies: ["MarkdownKit"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,12 +19,7 @@ let package = Package(
             exclude: libcmarkAsmFilePaths,
             cSettings: libcmarkAsmFilePaths.map { CSetting.headerSearchPath($0) }
         ),
-        .target(
-            name: "MarkdownKitObjC",
-            cSettings: [
-                .headerSearchPath("include"),
-            ]
-        ),
+        .target(name: "MarkdownKitObjC"),
         .target(name: "MarkdownKit", dependencies: ["libcmark", "MarkdownKitObjC"]),
         .testTarget(name: "MarkdownKitTests", dependencies: ["MarkdownKit"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,11 @@
 
 import PackageDescription
 
+let libcmarkAsmFilePaths = [
+    "src/case_fold_switch.inc",
+    "src/entities.inc"
+]
+
 let package = Package(
     name: "MarkdownKit",
     platforms: [.iOS(.v13)],
@@ -9,7 +14,11 @@ let package = Package(
         .library(name: "MarkdownKit", targets: ["MarkdownKit"])
     ],
     targets: [
-        .target(name: "libcmark"),
+        .target(
+            name: "libcmark",
+            exclude: libcmarkAsmFilePaths,
+            cSettings: libcmarkAsmFilePaths.map { CSetting.headerSearchPath($0) }
+        ),
         .target(
             name: "MarkdownKitObjC",
             cSettings: [

--- a/Sources/MarkdownKitObjC/include/MarkdownKitObjC.h
+++ b/Sources/MarkdownKitObjC/include/MarkdownKitObjC.h
@@ -1,1 +1,1 @@
-// File intentionally left blank
+#include "BaseTextStorage.h"


### PR DESCRIPTION
This package stopped building with Xcode 12.5b1 and Swift 5.4:

```
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "Headers/MarkdownKitObjC.h"
        ^
/Users/eliperkins/src/MarkdownKit/build/Release-iphoneos/MarkdownKitObjC.framework/Headers/MarkdownKitObjC.h:2:1: warning: umbrella header for module 'MarkdownKitObjC' does not include header 'BaseTextStorage.h'

^
/Users/eliperkins/src/MarkdownKit/Sources/MarkdownKit/Text/LayoutManager.swift:10:45: warning: cast from 'NSTextStorage?' to unrelated type 'TextStorage' always fails
        guard let textStorage = textStorage as? TextStorage, let document = textStorage.document else {
                                ~~~~~~~~~~~ ^   ~~~~~~~~~~~
/Users/eliperkins/src/MarkdownKit/Sources/MarkdownKit/Text/TextStorage+Manipulation.swift:51:32: error: cannot find 'string' in scope
            let replacement = (string as NSString).substring(with: innerRange)
                               ^~~~~~
/Users/eliperkins/src/MarkdownKit/Sources/MarkdownKit/Text/TextStorage+Manipulation.swift:67:34: error: value of type 'TextStorage' has no member 'string'
            let wordRange = self.string.wordRange(atIndex: selectedRange.location)
                            ~~~~ ^~~~~~
/Users/eliperkins/src/MarkdownKit/Sources/MarkdownKit/Text/TextStorage+Manipulation.swift:83:36: error: value of type 'TextStorage' has no member 'string'
                let string = (self.string as NSString).substring(with: wordRange)
                              ~~~~ ^~~~~~
```

This can be tested by selecting Xcode 12.5b1 with `xcode-select` and executing `xcodebuild build -sdk iphoneos -scheme MarkdownKit`.

Since `BaseTextStorage.h` wasn't included in the umbrella header, this class never ended up getting exposed to Swift. Including it allows for the module to expose it to Swift, and thus to allow Xcode to build it again.

---

Additionally, it looks like there's a couple new warnings from SPM with Swift 5.4:

```
❯ swift build
'MarkdownKit' /Users/eliperkins/src/MarkdownKit: warning: found 2 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/eliperkins/src/MarkdownKit/Sources/libcmark/src/entities.inc
    /Users/eliperkins/src/MarkdownKit/Sources/libcmark/src/case_fold_switch.inc
```

Based on [my brief understanding](https://stackoverflow.com/questions/48474161/whats-the-point-of-a-inc-file-in-c-c-what-situation-would-you-want-to-u) [of what `.inc` files are](https://stackoverflow.com/questions/38402525/difference-between-h-files-and-inc-files-in-c), it seems like these are assembly-ish macros, requiring no real compilation themselves, but rather are meant to be included as headers for sources that use them.

This moves these two files from `libcmark` to be included as C header files, and excludes them from compilation as sources.